### PR TITLE
TEMPLATE_LOADERS deprecated with django 1.10

### DIFF
--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django import VERSION as django_version
 from django.conf import settings as django_settings
 
 CACHE_LOADER_NAME = 'django_mobile.loader.CachedLoader'
@@ -30,7 +31,17 @@ class defaults(object):
     FLAVOURS_COOKIE_HTTPONLY = False
     FLAVOURS_SESSION_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []
-    for loader in django_settings.TEMPLATE_LOADERS:
+
+    if django_version >= 1.8:
+        loaders = []
+        for template_engine in django_settings.TEMPLATES:
+            loaders += template_engine.get('OPTIONS', {}).get('loaders', [])
+        DEFAULT_TEMPLATE_LOADERS = loaders
+        pass
+    else:
+        DEFAULT_TEMPLATE_LOADERS = django_settings.TEMPLATE_LOADERS
+
+    for loader in django_settings.DEFAULT_TEMPLATE_LOADERS:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:
             for cached_loader in loader[1]:
                 if cached_loader != DJANGO_MOBILE_LOADER:

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -41,7 +41,7 @@ class defaults(object):
     else:
         DEFAULT_TEMPLATE_LOADERS = django_settings.TEMPLATE_LOADERS
 
-    for loader in django_settings.DEFAULT_TEMPLATE_LOADERS:
+    for loader in DEFAULT_TEMPLATE_LOADERS:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:
             for cached_loader in loader[1]:
                 if cached_loader != DJANGO_MOBILE_LOADER:

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -32,7 +32,7 @@ class defaults(object):
     FLAVOURS_SESSION_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []
 
-    if django_version >= 1.8:
+    if django_version >= (1, 8):
         loaders = []
         for template_engine in django_settings.TEMPLATES:
             loaders += template_engine.get('OPTIONS', {}).get('loaders', [])

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -37,7 +37,6 @@ class defaults(object):
         for template_engine in django_settings.TEMPLATES:
             loaders += template_engine.get('OPTIONS', {}).get('loaders', [])
         DEFAULT_TEMPLATE_LOADERS = loaders
-        pass
     else:
         DEFAULT_TEMPLATE_LOADERS = django_settings.TEMPLATE_LOADERS
 


### PR DESCRIPTION
after this PR, we can fix the below warning that we keep seeing with our webserver repo

```
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_LOADERS.
```

cc @jstevens8213 
